### PR TITLE
Fix/equals implementations

### DIFF
--- a/src/main/java/com/kapoorlabs/kiara/domain/NullableOrderedString.java
+++ b/src/main/java/com/kapoorlabs/kiara/domain/NullableOrderedString.java
@@ -2,6 +2,8 @@ package com.kapoorlabs.kiara.domain;
 
 import com.kapoorlabs.kiara.constants.SdqlConstants;
 
+import java.util.Objects;
+
 /**
  * This class represents a wrapper built on top of a String, in which Null
  * values are ordered in the lowest position.
@@ -54,12 +56,7 @@ public class NullableOrderedString implements Comparable<NullableOrderedString> 
 		if (!(obj instanceof NullableOrderedString))
 			return false;
 		NullableOrderedString other = (NullableOrderedString) obj;
-		if (value == null) {
-			if (other.value != null)
-				return false;
-		} else if (!value.equals(other.value))
-			return false;
-		return true;
+		return Objects.equals(value, other.value);
 	}
 	
 	

--- a/src/main/java/com/kapoorlabs/kiara/domain/Range.java
+++ b/src/main/java/com/kapoorlabs/kiara/domain/Range.java
@@ -2,6 +2,8 @@ package com.kapoorlabs.kiara.domain;
 
 import lombok.Data;
 
+import java.util.Objects;
+
 
 /**
  * This class represents a single range. In case of alphanumeric ranges, prefix
@@ -63,22 +65,9 @@ public class Range implements Comparable<Range> {
 		if (!(obj instanceof Range))
 			return false;
 		Range other = (Range) obj;
-		if (lowerLimit == null) {
-			if (other.lowerLimit != null)
-				return false;
-		} else if (!lowerLimit.equals(other.lowerLimit))
-			return false;
-		if (prefix == null) {
-			if (other.prefix != null)
-				return false;
-		} else if (!prefix.equals(other.prefix))
-			return false;
-		if (upperLimit == null) {
-			if (other.upperLimit != null)
-				return false;
-		} else if (!upperLimit.equals(other.upperLimit))
-			return false;
-		return true;
+		return Objects.equals(lowerLimit, other.lowerLimit) &&
+		       Objects.equals(prefix, other.prefix) &&
+		       Objects.equals(upperLimit, other.upperLimit);
 	}
 
 	@Override

--- a/src/main/java/com/kapoorlabs/kiara/domain/SdqlNode.java
+++ b/src/main/java/com/kapoorlabs/kiara/domain/SdqlNode.java
@@ -2,6 +2,7 @@
 
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 
 import lombok.Getter;
 import lombok.Setter;
@@ -56,26 +57,11 @@ public class SdqlNode {
 		if (!(obj instanceof SdqlNode))
 			return false;
 		SdqlNode other = (SdqlNode) obj;
-		if (doubleValue == null) {
-			if (other.doubleValue != null)
-				return false;
-		} else if (!doubleValue.equals(other.doubleValue))
-			return false;
-		if (lowerBound != other.lowerBound)
-			return false;
-		if (parent == null) {
-			if (other.parent != null)
-				return false;
-		} else if (parent != other.parent)
-			return false;
-		if (stringValue == null) {
-			if (other.stringValue != null)
-				return false;
-		} else if (!stringValue.equals(other.stringValue))
-			return false;
-		if (upperBound != other.upperBound)
-			return false;
-		return true;
+		return Objects.equals(doubleValue, other.doubleValue) &&
+		       Objects.equals(lowerBound, other.lowerBound) &&
+		       Objects.equals(parent, other.parent) &&
+		       Objects.equals(stringValue, other.stringValue) &&
+		       Objects.equals(upperBound, other.upperBound);
 	}
 
 }

--- a/src/main/java/com/kapoorlabs/kiara/domain/SdqlNode.java
+++ b/src/main/java/com/kapoorlabs/kiara/domain/SdqlNode.java
@@ -57,9 +57,9 @@ public class SdqlNode {
 		if (!(obj instanceof SdqlNode))
 			return false;
 		SdqlNode other = (SdqlNode) obj;
-		return Objects.equals(doubleValue, other.doubleValue) &&
+		return parent == other.parent &&
+		       Objects.equals(doubleValue, other.doubleValue) &&
 		       Objects.equals(lowerBound, other.lowerBound) &&
-		       Objects.equals(parent, other.parent) &&
 		       Objects.equals(stringValue, other.stringValue) &&
 		       Objects.equals(upperBound, other.upperBound);
 	}


### PR DESCRIPTION
This PR addresses #14 by updating equals implementations in the following domain types:
- NullableOrderedString
- Range
- SdqlNode

to use the JDK's `Objects.equals` static method for checking property equality.